### PR TITLE
fix(css-styles): add background-size property to body

### DIFF
--- a/11-Order-summery-component/style.css
+++ b/11-Order-summery-component/style.css
@@ -24,10 +24,11 @@ body {
   display: grid;
   place-content: center;
   height: 100vh;
-  font-family: "Red Hat Display", sans-serif;
+  font-family: 'Red Hat Display', sans-serif;
   background-image: url(./images/pattern-background-desktop.svg);
   background-position: top;
   background-repeat: no-repeat;
+  background-size: 100% 100%;
 }
 .main-container {
   max-width: 35rem;


### PR DESCRIPTION
Hello @beRajeevKumar!
This fixes #52.

Now, the `pattern-background-desktop.svg` file fits the entire width of the screen, even when the screen is large, width-wise.

![fill-the-screen](https://github.com/user-attachments/assets/098d1d9b-2119-48e2-8710-16c968b0326c)

Code added:

https://github.com/peterdanwan/Frontend_Mentor/blob/c4338b07765d36f0743d4a6f1bb37a8dc88fe06c/11-Order-summery-component/style.css#L31
