### PR TITLE
Updated styles.css

### DIFF
--- a/18-chat-app-css-illustration/style.css
+++ b/18-chat-app-css-illustration/style.css
@@ -273,8 +273,59 @@ input[type="text"] {
   .container {
     grid-template-columns: 1fr;
     justify-items: center;
+    padding: 1rem;
+    gap: 4rem;
   }
   .content {
-    margin: auto 0;
+    margin: 2rem 0;
+    text-align: center;
+    padding: 1rem;
+    max-width: 90%;
+  }
+
+  .mobile {
+    max-width: 90%;
+    margin: 0 auto;
+  }
+  
+  .less-visible-bg
+  {
+    display: none;
+  }
+
+  .page-description {
+    margin-bottom: 3rem;
+  }
+  .notch {
+    left: 50%;
+    transform: translate(-50%, -30%);
+  }
+}
+
+@media (max-width: 375px) {
+  body {
+    padding: 1rem 0.5rem;
+  }
+
+  .container {
+    padding: 0.5rem;
+    gap: 3rem;
+    
+  }
+
+  .mobile {
+    max-width: 100%;
+  }
+
+  .content {
+    padding: 0.5rem;
+  }
+  .page-description {
+    font-size: 1.6rem;
+    margin-bottom: 2rem;
+  }
+  .notch {
+    left: 50%;
+    transform: translate(-50%, -30%);
   }
 }


### PR DESCRIPTION

<img width="494" alt="image" src="https://github.com/user-attachments/assets/29aa1d19-8d7b-413d-a616-f5dac77e4d62">

Solved #56
- [x] Bug 01: Mobile doesn't have any white space at the top in mobile mode.
- [x] Bug 02: The pink colour block is overriding the mobile design.
- [x] Bug 03: The text doesn't have any white space around it, and the footer text overlaps with the project description text.