### PR TITLE
add issue/PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: ​🐞 Bug
+description: Report an issue to help us improve the project.
+title: '[BUG] '
+labels: ["bug"]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      id: description
+      description: A brief description of the issue or bug you are facing, also include what you tried and what didn't work.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshots
+      id: screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Any additional information?
+      id: extrainfo
+      description: Any additional information or Is there anything we should know about this bug?
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browser are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: 'Checklist'
+      options:
+        - label: 'I have checked the existing issues'
+          required: true
+
+        - label: 'I have read the [Contributing Guidelines](https://github.com/beRajeevKumar/Frontend_Mentor/blob/main/Code_Of_Conduct.md)'
+          required: true
+        - label: "I'm a GSSoC'24-Extd contributor"
+        - label: "I'm a Hacktoberfest'24 contributor"
+
+        - label: 'I am willing to work on this issue (optional)'
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,34 @@
+name: Feature Request 💡
+description: Have any new idea or new feature for Canvas-Editor? Please suggest!
+title: '[Feat]'
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of any alternative solution or features you've considered.
+    validations:
+      required: true
+  - type: textareas
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: 'Checklist'
+      options:
+        - label: 'I have checked the existing issues'
+          required: true
+
+        - label: 'I have read the [Contributing Guidelines](https://github.com/beRajeevKumar/Frontend_Mentor/blob/main/Code_Of_Conduct.md)'
+          required: true
+        - label: "I'm a GSSoC'24-Extd contributor"
+        - label: "I'm a Hacktoberfest'24 contributor"
+
+        - label: 'I am willing to work on this issue (optional)'
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What does this PR do?
+
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+Fixes #(issue)
+
+<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
+
+## Type of change
+
+<!-- Please delete bullets that are not relevant. -->
+
+- Bug fix (non-breaking change which fixes an issue)
+- Chore (refactoring code, technical debt, workflow improvements)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+
+## How should this be tested?
+
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
+
+- [ ] Test A
+- [ ] Test B
+
+## Mandatory Tasks
+
+- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,16 @@
+name: Greetings
+
+on: [pull_request_target, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: "👋 Thank you @${{ github.actor }} for raising an issue! We appreciate your effort in helping us improve. Our team will review it shortly. Stay tuned!"
+        pr-message: " 🎉 Thank you @${{ github.actor }} for your contribution! Your pull request has been submitted successfully. A maintainer will review it as soon as possible. We appreciate your support in making this project better"


### PR DESCRIPTION
## Description:
fix #123 
This Pull Request adds standardized templates for both Issues and Pull Requests to ensure consistent formatting and information when reporting bugs or submitting code changes.

## Changes Introduced:

- Added a .github/ISSUE_TEMPLATE/issue_template.md for bug report submissions.
- Added a .github/PULL_REQUEST_TEMPLATE.md for pull request submissions.

## Benefits:

- Improves the clarity and consistency of Issue and PR submissions.
- Helps maintainers and contributors understand the context and details of submissions.

## Screeshots
 
![image](https://github.com/user-attachments/assets/d7a3ce36-4fa7-4e4a-94aa-a3927e56c027)

